### PR TITLE
Add more PR info to the slack message

### DIFF
--- a/lib/api.slack.js
+++ b/lib/api.slack.js
@@ -12,22 +12,25 @@ class SlackAPI {
   }
 
   createCRMessage(codeReview) {
+    // Only add the extra info on private repos; public repos already show it
+    let attachments = codeReview.isRepoPublic() ? '' : JSON.stringify([
+      {
+        color: '#eb1767',
+        fallback: codeReview.title(),
+        title: codeReview.title(),
+        title_link: codeReview.pullRequestUrl,
+        text: codeReview.body(),
+        author_icon: codeReview.authorThumbnail(),
+        author_name: codeReview.authorName(),
+        mrkdwn_in: ['text']
+      }
+    ])
+
     let options = this._requestOptions("chat.postMessage", {
       channel: codeReview.channelID,
       text: codeReview.formattedMessage(),
       as_user: true,
-      attachments: JSON.stringify([
-        {
-          color: '#eb1767',
-          fallback: codeReview.title(),
-          title: codeReview.title(),
-          title_link: codeReview.pullRequestUrl,
-          text: codeReview.body(),
-          author_icon: codeReview.authorThumbnail(),
-          author_name: codeReview.authorName(),
-          mrkdwn_in: ['text']
-        }
-      ])
+      attachments: attachments
     });
 
     return request(options).then((response) => {

--- a/lib/api.slack.js
+++ b/lib/api.slack.js
@@ -15,7 +15,19 @@ class SlackAPI {
     let options = this._requestOptions("chat.postMessage", {
       channel: codeReview.channelID,
       text: codeReview.formattedMessage(),
-      as_user: true
+      as_user: true,
+      attachments: JSON.stringify([
+        {
+          color: '#eb1767',
+          fallback: codeReview.title(),
+          title: codeReview.title(),
+          title_link: codeReview.pullRequestUrl,
+          text: codeReview.body(),
+          author_icon: codeReview.authorThumbnail(),
+          author_name: codeReview.authorName(),
+          mrkdwn_in: ['text']
+        }
+      ])
     });
 
     return request(options).then((response) => {

--- a/lib/api.slack.js
+++ b/lib/api.slack.js
@@ -12,25 +12,23 @@ class SlackAPI {
   }
 
   createCRMessage(codeReview) {
-    // Only add the extra info on private repos; public repos already show it
-    let attachments = codeReview.isRepoPublic() ? '' : JSON.stringify([
-      {
-        color: '#eb1767',
-        fallback: codeReview.title(),
-        title: codeReview.title(),
-        title_link: codeReview.pullRequestUrl,
-        text: codeReview.body(),
-        author_icon: codeReview.authorThumbnail(),
-        author_name: codeReview.authorName(),
-        mrkdwn_in: ['text']
-      }
-    ])
-
     let options = this._requestOptions("chat.postMessage", {
       channel: codeReview.channelID,
       text: codeReview.formattedMessage(),
       as_user: true,
-      attachments: attachments
+      unfurl_links: false,
+      attachments: JSON.stringify([
+        {
+          color: '#eb1767',
+          fallback: codeReview.title(),
+          title: codeReview.title(),
+          title_link: codeReview.pullRequestUrl,
+          text: codeReview.body(),
+          author_icon: codeReview.authorThumbnail(),
+          author_name: codeReview.authorName(),
+          mrkdwn_in: ['text']
+        }
+      ])
     });
 
     return request(options).then((response) => {

--- a/lib/codeReview.js
+++ b/lib/codeReview.js
@@ -131,10 +131,6 @@ class CodeReview {
     return this._githubPR.title
   }
 
-  isRepoPublic() {
-    return !this._githubPR.base.repo.private
-  }
-
   authorName() {
     return this._githubPR.user.login
   }

--- a/lib/codeReview.js
+++ b/lib/codeReview.js
@@ -131,6 +131,10 @@ class CodeReview {
     return this._githubPR.title
   }
 
+  isRepoPublic() {
+    return !this._githubPR.base.repo.private
+  }
+
   authorName() {
     return this._githubPR.user.login
   }

--- a/lib/codeReview.js
+++ b/lib/codeReview.js
@@ -127,6 +127,25 @@ class CodeReview {
     return `${this._typeEmojis()}${this.pullRequestUrl} ${this._sizeEmoji()}`
   }
 
+  title() {
+    return this._githubPR.title
+  }
+
+  authorName() {
+    return this._githubPR.user.login
+  }
+
+  body() {
+    // convert header markdown tags (#) to bold; slack doesn't support header
+    var body = this._githubPR.body
+    body = body.replace(/(^|\n)#+(.+)/g, '*$2*')
+    return body
+  }
+
+  authorThumbnail() {
+    return this._githubPR.user.avatar_url
+  }
+
   _sizeEmoji() {
     let emojis;
 

--- a/spec/slack_spec.js
+++ b/spec/slack_spec.js
@@ -23,7 +23,10 @@ describe(`${__filename.slice(__dirname.length + 1)}: Slack API`, () => {
     codeReview = {
       channelID: "C0K673QFM",
       formattedMessage: () => "message",
-      isRepoPublic: () => true
+      title: () => "title",
+      body: () => "body",
+      authorThumbnail: () => "",
+      authorName: () => "Someone"
     };
   });
 

--- a/spec/slack_spec.js
+++ b/spec/slack_spec.js
@@ -22,7 +22,8 @@ describe(`${__filename.slice(__dirname.length + 1)}: Slack API`, () => {
   beforeEach(() => {
     codeReview = {
       channelID: "C0K673QFM",
-      formattedMessage: () => "message"
+      formattedMessage: () => "message",
+      isRepoPublic: () => true
     };
   });
 


### PR DESCRIPTION
**Why?**
It'd be nice to know more about the PR (title, creator, details)
This addresses https://github.com/smashingboxes/code-review-bot/issues/14

**What Changed?**
Add an attachment to the slack message with more PR info, but only if the repo is private

This will make the PRs in the code-review channel more descriptive but also much taller. It might be nice to keep just the username, the user icon, and the PR title, and ditch the PR body if PRs get lost off the top of the screen.