### PR TITLE
Fix color change

### DIFF
--- a/lib/codeReview.js
+++ b/lib/codeReview.js
@@ -46,7 +46,15 @@ class CodeReview {
     let isInactive = prEvents.isInactive(lastActionableEvent);
 
     if (isInactive) {
-      this._retireCodeReview(lastActionableEvent);
+      github.getPRResource(this._githubPRParams).then(githubResponse => {
+        let merged = githubResponse[0].merged;
+        if (merged) {
+          // 'merged' is not actualy a PR event. We need to get
+          // the PR data again to see if it has been merged.
+          lastActionableEvent = 'merged';
+        }
+        this._retireCodeReview(lastActionableEvent);
+      });
     } else {
       this.pollGithubForComments();
     }

--- a/lib/codeReview.js
+++ b/lib/codeReview.js
@@ -144,7 +144,9 @@ class CodeReview {
   body() {
     // convert header markdown tags (#) to bold; slack doesn't support header
     var body = this._githubPR.body
-    body = body.replace(/(^|\n)#+(.+)/g, '*$2*')
+    if (body) {
+      body = body.replace(/(^|\n)#+(.+)/g, '*$2*')
+    }
     return body
   }
 

--- a/lib/codeReview.js
+++ b/lib/codeReview.js
@@ -35,17 +35,18 @@ class CodeReview {
       return;
     }
 
-    var itemEvent = 'none';
-    let doClosePoll = this._githubPREvents.reduce((prev, item) => {
-      if (prEvents.isInactive(item.event)) {
-        itemEvent = item.event
-        return true;
+    // Multiple events can stack up (closed & reopened, for example). The last event wins.
+    let lastActionableEvent = this._githubPREvents.reduce( (prev, item) => {
+      if (prEvents.isActionableEvent(item.event)) {
+        return item.event;
       }
       return prev;
-    }, false);
+    }, 'none');
 
-    if (doClosePoll) {
-      this._retireCodeReview(itemEvent);
+    let isInactive = prEvents.isInactive(lastActionableEvent);
+
+    if (isInactive) {
+      this._retireCodeReview(lastActionableEvent);
     } else {
       this.pollGithubForComments();
     }

--- a/lib/util/prEvents.js
+++ b/lib/util/prEvents.js
@@ -5,6 +5,7 @@ class PREvents {
   static color(itemEvent) {
     let colors = {
       none: '#6cc644',
+      reopened: '#6cc644',
       closed: '#777777',
       merged: '#6e5494',
       head_ref_deleted: '#777777'
@@ -15,6 +16,15 @@ class PREvents {
   static isInactive(itemEvent) {
     let inactiveEvents = ['closed', 'merged', 'head_ref_deleted']
     return inactiveEvents.indexOf(itemEvent) > -1
+  }
+
+  static isActive(itemEvent) {
+    let activeEvents = ['reopened']
+    return activeEvents.indexOf(itemEvent) > -1
+  }
+
+  static isActionableEvent(itemEvent) {
+    return this.isInactive(itemEvent) || this.isActive(itemEvent);
   }
 
   static emoji(itemEvent) {

--- a/lib/util/prEvents.js
+++ b/lib/util/prEvents.js
@@ -19,7 +19,7 @@ class PREvents {
   }
 
   static isActive(itemEvent) {
-    let activeEvents = ['reopened']
+    let activeEvents = ['none', 'reopened']
     return activeEvents.indexOf(itemEvent) > -1
   }
 


### PR DESCRIPTION
**Why?**
* 'merged' never actually comes as an event name
* 'closed' was always winning, so a pr would still look closed if it was closed & then reopened

**What Changed?**
* From the list of PR events, use the last event name that we recognize to show the correct color
* Check the PR again when a 'closed' event happens and see if it's been merged.