### PR TITLE
Fixes error handling and slack error response messaging

### DIFF
--- a/lib/crbot.js
+++ b/lib/crbot.js
@@ -48,8 +48,10 @@ class CrBot {
     return this.getPR(githubPRParams)
       .then(githubResponse => {
         if ( !githubResponse[0] ) {
-
-          return false;
+          this.onSlackMessageIsBad(res, req);
+          var err = (new Error(`Slack Message Did Not Contain a URL that could be found: ${req.body.text}`));
+          throw err;
+          return err;
         }
 
         newCR = new CodeReview(githubResponse, githubPRParams, req.body);

--- a/lib/crbot.js
+++ b/lib/crbot.js
@@ -47,7 +47,7 @@ class CrBot {
 
     return this.getPR(githubPRParams)
       .then(githubResponse => {
-        if ( !githubResponse[0] ) {
+        if (!githubResponse[0]) {
           this.onSlackMessageIsBad(res, req);
           var err = (new Error(`Slack Message Did Not Contain a URL that could be found: ${req.body.text}`));
           throw err;

--- a/lib/crbot.js
+++ b/lib/crbot.js
@@ -30,19 +30,28 @@ class CrBot {
     return null;
   }
 
-  onIncomingCodeReview(req, res, next) {
-    let githubPRParams = this.getGitHubPRParams(req.body.text);
-    let newCR;
-    if (!githubPRParams) {
-      return res.status(404)
+  onSlackMessageIsBad(res, req) {
+    return res.status(404)
         .end(`Beep:Boop.
           I could not find your repo.
           Are you sure it is accessible to me?
           Please double check your URL: ${req.body.text}`);
+  }
+
+  onIncomingCodeReview(req, res, next) {
+    let githubPRParams = this.getGitHubPRParams(req.body.text);
+    let newCR;
+    if (!githubPRParams) {
+      return this.onSlackMessageIsBad(res, req);
     }
 
     return this.getPR(githubPRParams)
       .then(githubResponse => {
+        if ( !githubResponse[0] ) {
+
+          return false;
+        }
+
         newCR = new CodeReview(githubResponse, githubPRParams, req.body);
         newCR.emitter.once('killme', () => {
           this.removeInactivePullRequest(newCR);

--- a/spec/crbot_spec.js
+++ b/spec/crbot_spec.js
@@ -70,6 +70,26 @@ describe(`${__filename.slice(__dirname.length + 1)}: CRBot Server`, () => {
       });
     });
 
+    it('returns 404', (done) => {
+      formData = {
+        token: 'test-token',
+        team_id: 'T0001',
+        team_domain: 'example',
+        channel_id: 'C2147483705',
+        channel_name: 'test',
+        user_id: 'U2147483697',
+        user_name: 'Steve',
+        command: '/cr',
+        text: 'blah blah blah this is an error',
+        response_url: 'https://hooks.slack.com/commands/1234/5678'
+      }
+
+      request.post(base_url + 'code_review', { form: formData }, (error, response, body) => {
+        expect(response.statusCode).toBe(404);
+        done();
+      });
+    });
+
     it('adds a new CodeReview Instance', (done) => {
 
       let req = {

--- a/spec/crbot_spec.js
+++ b/spec/crbot_spec.js
@@ -144,12 +144,9 @@ describe(`${__filename.slice(__dirname.length + 1)}: CRBot Server`, () => {
         fail();
         done();
       }).then((codeReview) => {
-        //console.log(codeReview._created);
         codeReview.emitter.on('killme', () => {
           done();
         }).catch((err) => {
-          //console.log(err);
-          //console.trace();
           fail();
           done();
         })

--- a/spec/crbot_spec.js
+++ b/spec/crbot_spec.js
@@ -50,6 +50,7 @@ describe(`${__filename.slice(__dirname.length + 1)}: CRBot Server`, () => {
   describe('POST /code_review', () => {
 
     it('returns 200', (done) => {
+      mockSlack();
       formData = {
         token: 'test-token',
         team_id: 'T0001',
@@ -70,7 +71,29 @@ describe(`${__filename.slice(__dirname.length + 1)}: CRBot Server`, () => {
       });
     });
 
-    it('returns 404', (done) => {
+    it('returns 404 for a malformed pr', (done) => {
+      mockSlack();
+      formData = {
+        token: 'test-token',
+        team_id: 'T0001',
+        team_domain: 'example',
+        channel_id: 'C2147483705',
+        channel_name: 'test',
+        user_id: 'U2147483697',
+        user_name: 'Steve',
+        command: '/cr',
+        text: 'blah blah blah this is an error',
+        response_url: 'https://hooks.slack.com/commands/1234/5678'
+      }
+
+      request.post(base_url + 'code_review', { form: formData }, (error, response, body) => {
+        expect(response.statusCode).toBe(404);
+        done();
+      });
+    });
+
+    it('returns 404 for a missing pr', (done) => {
+      mockSlack();
       formData = {
         token: 'test-token',
         team_id: 'T0001',
@@ -91,6 +114,7 @@ describe(`${__filename.slice(__dirname.length + 1)}: CRBot Server`, () => {
     });
 
     it('adds a new CodeReview Instance', (done) => {
+      mockSlack();
 
       let req = {
         body : {
@@ -120,12 +144,12 @@ describe(`${__filename.slice(__dirname.length + 1)}: CRBot Server`, () => {
         fail();
         done();
       }).then((codeReview) => {
-        console.log(codeReview._created);
+        //console.log(codeReview._created);
         codeReview.emitter.on('killme', () => {
           done();
         }).catch((err) => {
-          console.log(err);
-          console.trace();
+          //console.log(err);
+          //console.trace();
           fail();
           done();
         })

--- a/spec/support/mockGithub.js
+++ b/spec/support/mockGithub.js
@@ -632,5 +632,14 @@ nock('https://api.github.com:443', {
   'x-github-request-id': '48CDAEA0:1601F:DE69035:56C7851E'
 });
 
+nock('https://api.github.com:443', {
+  "encodedQueryParams": true
+})
+.persist()
+.get('/repos/smashingboxes/code-review-bot/pulls/1111111')
+.query(true)
+.reply(404, {
+  error: 'No PR here'
+});
 
 }


### PR DESCRIPTION
# Why?
- Two different errors need to be handled -- a slack message that doesn't have a proper repo URL, and a slack message that contains a URL that can't be found. #26 

# What changed?
- Added error handling
- Added test for error handling