### PR TITLE
Just remove the lock extension from detection

### DIFF
--- a/lib/util/extensions.json
+++ b/lib/util/extensions.json
@@ -406,7 +406,6 @@
     ".litcoffee": "Literate CoffeeScript",
     ".ll": "LLVM",
     ".lmi": "Python",
-    ".lock": "JSON",
     ".logtalk": "Logtalk",
     ".lol": "LOLCODE",
     ".lookml": "LookML",


### PR DESCRIPTION
## What Changed
* Remove lock from list of detectable extensions

## Why
* .lock usually refers to Gemfile updates. No need to be marking them as JS.