### PR TITLE
Have HTML icon show up for erb templates

### DIFF
--- a/lib/util/type_to_emoji.json
+++ b/lib/util/type_to_emoji.json
@@ -11,7 +11,7 @@
   "HTML": ":cr-html:",
   "Jade": ":cr-html:",
   "Slim": ":cr-html:",
-  "ERB": ":cr-html:",
+  "HTML+ERB": ":cr-html:",
   "Haml": ":cr-html:",
   "Objective-C": ":cr-ios:",
   "Swift": ":cr-swift:",


### PR DESCRIPTION
WHY
erb tempates weren't registering as html

WHAT CHANGED
Updated the mapping