### PR TITLE
Size improvements

### DIFF
--- a/lib/codeReview.js
+++ b/lib/codeReview.js
@@ -166,7 +166,8 @@ class CodeReview {
   _sizeEmoji() {
     let emojis;
     
-    var key = this._roundDownToList(this._githubPR.additions, Object.keys(sizeMap));
+    var size = (this._githubPR.additions * 2) + this._githubPR.deletions;
+    var key = this._roundDownToList(size, Object.keys(sizeMap));
     return sizeMap[key];
   }
 

--- a/lib/codeReview.js
+++ b/lib/codeReview.js
@@ -165,16 +165,9 @@ class CodeReview {
 
   _sizeEmoji() {
     let emojis;
-
-    if (this._githubPR.additions < 50) {
-      emojis = sizeMap["small"];
-    } else if (this._githubPR.additions < 200) {
-      emojis = sizeMap["medium"];
-    } else {
-      emojis = sizeMap["large"];
-    }
-
-    return emojis[Math.floor(Math.random() * emojis.length)];
+    
+    var key = this._roundDownToList(this._githubPR.additions, Object.keys(sizeMap));
+    return sizeMap[key];
   }
 
   _typeEmojis() {
@@ -198,6 +191,22 @@ class CodeReview {
   _uniq() {
     const seen = {};
     return (emoji) => !(emoji in seen) && (seen[emoji] = 1);
+  }
+  
+  // Round the given number up to the nearest item in the list
+  _roundDownToList(num, roundList) {
+    var currentRound = 0;
+    var sortedList = roundList.sort(function(a, b){return a-b});
+    
+    for (var i = 0; i < sortedList.length; i++) {
+      var compareNumber = sortedList[i];
+      if (compareNumber <= num) {
+        currentRound = compareNumber;
+      } else {
+        return currentRound;
+      }
+    }
+    return currentRound;
   }
 }
 

--- a/lib/util/size.json
+++ b/lib/util/size.json
@@ -1,5 +1,13 @@
 {
-  "small": [":cr-atomic:", ":ant:"],
-  "medium": [":monkey:", ":cow:", ":frog:", ":doge:"],
-  "large": [":elephant:"]
+  "0": ":cr-atomic:",
+  "10": ":ant:",
+  "30": ":frog:",
+  "50": ":rooster:",
+  "75": ":doge:",
+  "100": ":monkey:",
+  "150": ":cow:",
+  "200": ":elephant:",
+  "300": ":whale:",
+  "500": ":earth_americas:",
+  "1000": ":milky_way:"
 }

--- a/lib/util/size.json
+++ b/lib/util/size.json
@@ -1,13 +1,17 @@
 {
   "0": ":cr-atomic:",
   "10": ":ant:",
-  "30": ":frog:",
-  "50": ":rooster:",
-  "75": ":doge:",
-  "100": ":monkey:",
-  "150": ":cow:",
-  "200": ":elephant:",
-  "300": ":whale:",
-  "500": ":earth_americas:",
-  "1000": ":milky_way:"
+  "20": ":frog:",
+  "60": ":rabbit2:",
+  "80": ":cat:",
+  "100": ":rooster:",
+  "150": ":doge:",
+  "200": ":monkey:",
+  "300": ":cow:",
+  "400": ":elephant:",
+  "600": ":whale:",
+  "800": ":death_star:",
+  "1000": ":earth_americas:",
+  "1500": ":saturn:",
+  "2000": ":milky_way:"
 }


### PR DESCRIPTION
### Why?

- There were only three sizes: small, medium, large. A random icon was picked for those sizes. That was misleading, because 🐸  is definitely smaller than 🐄.
- Deletions weren't taken into account, so a PR that deletes a whole repo would be 🐜 

### What changed?

- One icon per size.
- Add a few more icons
- Count deletions in size factor, but weight them as half an addition. (It's easier to review a deletion than an addition)