### PR TITLE
Add an endpoint for listing open PRs

### DIFF
--- a/lib/api.slack.js
+++ b/lib/api.slack.js
@@ -12,7 +12,7 @@ class SlackAPI {
     this.config = config;
   }
 
-  makeMessageData(codeReview, itemEvent) {
+  makeCRMessageData(codeReview, itemEvent) {
     return {
       channel: codeReview.channelID,
       text: codeReview.formattedMessage(),
@@ -33,8 +33,21 @@ class SlackAPI {
     }
   }
 
+  makeCRQueueMessageData(codeReviews, slackChannelID) {
+    let codeReviewLines = codeReviews.map((codeReview) => { return codeReview.formattedMessage(); });
+    let uniqed = codeReviewLines.filter(function(v,i) { return codeReviewLines.indexOf(v) == i; });
+    let message = uniqed.join('\n');
+
+    return {
+      response_type: "in_channel",
+      text: message,
+      as_user: true,
+      unfurl_links: false
+    }
+  }
+
   createCRMessage(codeReview) {
-    let options = this._requestOptions("chat.postMessage", this.makeMessageData(codeReview));
+    let options = this._requestOptions("chat.postMessage", this.makeCRMessageData(codeReview));
 
     return request(options).then((response) => {
       if(!response.ok) { throw new Error(response.error); }
@@ -49,7 +62,7 @@ class SlackAPI {
   updateCRMessage(codeReview, itemEvent){
     if (!codeReview.messageIDs) return Promise.reject('no slack messageIDs yet');
 
-    let updatedData = this.makeMessageData(codeReview, itemEvent)
+    let updatedData = this.makeCRMessageData(codeReview, itemEvent)
     updatedData.ts = codeReview.messageIDs[0]
 
     let options = this._requestOptions("chat.update", updatedData);

--- a/lib/crbot.js
+++ b/lib/crbot.js
@@ -73,10 +73,17 @@ class CrBot {
       .catch(err => next(err));
   }
 
+  onIncomingPRQueue(req, res, next) {
+    let channel_id = req.body.channel_id;
+    let response = this.slack.makeCRQueueMessageData(this.activeReviews, channel_id);
+    res.status(200).send(response);
+  }
+
   setup() {
     app.use(bodyParser.urlencoded({extended: true}));
 
     app.post('/code_review', this.onIncomingCodeReview.bind(this));
+    app.post('/pr_queue', this.onIncomingPRQueue.bind(this));
 
     this.github = require('./api.github');
     this.github.authenticate(this.config);

--- a/spec/slack_spec.js
+++ b/spec/slack_spec.js
@@ -51,7 +51,7 @@ describe(`${__filename.slice(__dirname.length + 1)}: Slack API`, () => {
 
     let testUpdateStatus = (codeReview, itemStatus) => {
       return slack.createCRMessage(codeReview).then((codeReview) => {
-        let openMessage = slack.makeMessageData(codeReview, itemStatus);
+        let openMessage = slack.makeCRMessageData(codeReview, itemStatus);
         let attachments = JSON.parse(openMessage.attachments);
         expect(attachments[0].color).toBe(prEvents.color(itemStatus));
       });


### PR DESCRIPTION
### Why?

- PRs often get lost in the flood of text in the code review channel

### What changed?

- Added a `/pr_queue` endpoint that can be used to get a list of open PRs