### PR TITLE
Errors were not displayed in stderr properly

### DIFF
--- a/lib/api.github.js
+++ b/lib/api.github.js
@@ -50,7 +50,8 @@ class GitHubAPI {
       this._getAPIPromise(commentPRParams, 'issues', 'getComments')
     ];
     return Promise.all(promises).catch((err) => {
-      console.log(err, eventPRParams, commentPRParams); console.trace();
+      console.error(err, eventPRParams, commentPRParams);
+      console.trace();
     });
   }
 
@@ -59,7 +60,10 @@ class GitHubAPI {
       this._getAPIPromise(pullRequestParams, 'pullRequests', 'get'),
       this._getAPIPromise(pullRequestParams, 'pullRequests', 'getFiles')
     ];
-    return Promise.all(promises).catch((err) => { console.log(err); console.trace(); });
+    return Promise.all(promises).catch((err) => {
+      console.error(err);
+      console.trace();
+    });
   }
 }
 

--- a/lib/api.slack.js
+++ b/lib/api.slack.js
@@ -64,7 +64,7 @@ class SlackAPI {
       })
       .catch((err) => {
         console.trace();
-        console.log(SlackAPI, err);
+        console.error(SlackAPI, err);
         return codeReview;
       });
   }
@@ -84,7 +84,7 @@ class SlackAPI {
       })
       .catch((err) => {
         console.trace();
-        console.log(SlackAPI, err);
+        console.error(SlackAPI, err);
         return codeReview;
       });
   }
@@ -102,13 +102,13 @@ class SlackAPI {
           return codeReview;
         }).catch((err) => {
           console.trace();
-          console.log(SlackAPI, err);
+          console.error(SlackAPI, err);
           return codeReview;
        });
       }))
       .catch((err) => {
         console.trace();
-        console.log(SlackAPI, err);
+        console.error(SlackAPI, err);
         return codeReview;
       });
   }
@@ -128,7 +128,7 @@ class SlackAPI {
       })
       .catch((err) => {
         console.trace();
-        console.log(SlackAPI, err);
+        console.error(SlackAPI, err);
         return codeReview;
      });
   }
@@ -149,7 +149,7 @@ class SlackAPI {
       })
       .catch((err) => {
         console.trace();
-        console.log(SlackAPI, err);
+        console.error(SlackAPI, err);
         return codeReview;
       });
   }

--- a/lib/codeReview.js
+++ b/lib/codeReview.js
@@ -104,7 +104,7 @@ class CodeReview {
         this.emitter.removeAllListeners(this.DEATH_EVENT);
       })
       .catch((err)=>{
-        console.log(CodeReview, 'Error removing from storage', err);
+        console.error(CodeReview, 'Error removing from storage', err);
         console.trace();
         this.emitter.emit(this.DEATH_EVENT, this);
         this.emitter.removeAllListeners(this.DEATH_EVENT);
@@ -135,7 +135,7 @@ class CodeReview {
       reviewers.forEach((reviewer, index) => {
         if (index > this.numberOfReviwers-1) {
           slack.addReactionToCRMessage(this, this.EMOJI_REVIEWED).catch((err) => {
-            console.log(err);
+            console.error(err);
             console.trace();
           });
         }
@@ -188,7 +188,7 @@ class CodeReview {
         this.runPollChecks();
       })
       .catch((err) => {
-        console.log(err);
+        console.error(CodeReview, 'Error: github.getPRChanges', err);
         console.trace();
       });
   }

--- a/lib/codeReview.js
+++ b/lib/codeReview.js
@@ -41,6 +41,7 @@ class CodeReview {
     setTimeout(() => {
       this.checkGithubActivity();
     },1000*index);
+
     return this;
   }
 
@@ -85,7 +86,10 @@ class CodeReview {
 
   _retireCodeReview(itemEvent) {
     console.log('retiring CR:', itemEvent);
-    this.poll && clearTimeout(this.poll);
+    if (this.poll) {
+      clearTimeout(this.poll);
+      this.poll = null;
+    }
 
     console.log('timeout cleared.', this.pullRequestUrl);
     if (prEvents.emoji(itemEvent)) {

--- a/lib/crbot.js
+++ b/lib/crbot.js
@@ -103,11 +103,6 @@ class CrBot {
 
     return this._loadStoredPRs().then(() => {
       console.log(CrBot, 'Setup Complete');
-
-      // Testing
-      // setInterval(()=>{
-      //   this._testPRList();
-      // }, 1000)
     });
   }
 

--- a/lib/crbot.js
+++ b/lib/crbot.js
@@ -81,12 +81,10 @@ class CrBot {
   onIncomingPRQueue(req, res, next) {
     let channel_id = req.body.channel_id;
     console.log(CrBot, 'onIncomingPRQueue', this.activeReviews.length);
-    let response = this.slack.makeCRQueueMessageData(this.activeReviews, channel_id);
+    let response = this.slack.makeCRQueueMessageData(this.activeReviews.filter((cr) => {
+      return !!cr.poll;
+    }), channel_id);
     res.status(200).send(response);
-  }
-
-  _testPRList() {
-    console.log('List PRs:', this.slack.makeCRQueueMessageData(this.activeReviews, 'log') );
   }
 
   setup() {


### PR DESCRIPTION
# Why?
- Errors were not being logged correctly to stderr
- Occasionally some PRs may not be removed from the `cr-list` command

# What changed?
- Used `console.error` to correctly output errors
- check for active timeout before listing in `cr-list` command