### PR TITLE
Fixes missing message ids reference from redis

### DIFF
--- a/lib/api.slack.js
+++ b/lib/api.slack.js
@@ -58,8 +58,7 @@ class SlackAPI {
     return request(options)
       .then((response) => {
         if(!response.ok) { throw new Error(response.error); }
-        codeReview.messageIDs = codeReview.messageIDs || [];
-        codeReview.messageIDs.push(response.ts);
+        codeReview.updateMessageIDs(response.ts);
         return codeReview;
       })
       .catch((err) => {
@@ -143,8 +142,7 @@ class SlackAPI {
     return request(options)
       .then((response) => {
         if(!response.ok) { throw new Error(response.error); }
-        codeReview.messageIDs = codeReview.messageIDs || [];
-        codeReview.messageIDs.push(response.ts);
+        codeReview.updateMessageIDs(response.ts);
         return codeReview;
       })
       .catch((err) => {

--- a/lib/codeReview.js
+++ b/lib/codeReview.js
@@ -154,6 +154,11 @@ class CodeReview {
     this._syncRedis();
   }
 
+  updateMessageIDs(messageID) {
+    this.messageIDs = this.messageIDs || [];
+    this.messageIDs.push(messageID);
+  }
+
   _syncRedis() {
     let data = JSON.stringify({
       _created: this._created,
@@ -162,6 +167,7 @@ class CodeReview {
       _githubPRParams: this._githubPRParams,
       _slackRequest: this._slackRequest,
       pullRequestUrl: this.pullRequestUrl,
+      messageIDs: this.messageIDs,
       channelID: this.channelID
     });
     redisAdapter.set(this.pullRequestUrl, data);

--- a/lib/crbot.js
+++ b/lib/crbot.js
@@ -121,7 +121,7 @@ class CrBot {
     let oldLen = this.activeReviews.length;
     let index = this.activeReviews.indexOf(pr);
     let crItem = this.activeReviews.splice(index, 1);
-    console.log('Removed PR. PRs left: ', oldLen, '/', this.activeReviews.length);
+    console.log('Removed PR. PRs left: ', this.activeReviews.length, '/',  oldLen);
   }
 
   getPR(pullRequestParams) {

--- a/spec/slack_spec.js
+++ b/spec/slack_spec.js
@@ -26,6 +26,10 @@ describe(`${__filename.slice(__dirname.length + 1)}: Slack API`, () => {
       formattedMessage: () => "message",
       title: () => "title",
       body: () => "body",
+      updateMessageIDs: (msgID) => {
+        codeReview.messageIDs = codeReview.messageIDs || [];
+        codeReview.messageIDs.push(msgID);
+      },
       authorThumbnail: () => "",
       authorName: () => "Someone"
     };


### PR DESCRIPTION
# Why?
- Slack Message IDs were not properly stored in redis, leading to CR bot dropping the ball after being bounced.

# What changed?
- Storing em in redis now.