### PR TITLE
Fixes issue with PRs improperly stored that haunt the cr-list command

### DIFF
--- a/lib/codeReview.js
+++ b/lib/codeReview.js
@@ -27,6 +27,7 @@ class CodeReview {
 
       this.pullRequestUrl = this._githubPR.html_url;
       this.channelID = this._slackRequest.channel_id;
+      //this.messageIDs added by a later method. this should probably be fixed.
       this._syncRedis();
     }
   }
@@ -36,6 +37,10 @@ class CodeReview {
     for (let index in dataObj) {
       this[index] = dataObj[index];
       console.log(index);
+    }
+    if ( !this.messageIDs || this.messageIDs.length < 1 ) {
+      redisAdapter.delete(this.pullRequestUrl);
+      return null;
     }
     this._syncRedis();
     setTimeout(() => {

--- a/lib/crbot.js
+++ b/lib/crbot.js
@@ -108,10 +108,14 @@ class CrBot {
     return (redisAdapter
       .getAll('https://github.com/*')
       .then((reply) => {
-        this.activeReviews = this.activeReviews.concat(reply.map((crData, index) => {
-          let _cr = new CodeReview();
-          return _cr.bootstrapFromStorage(crData, index);
-        }))
+        this.activeReviews = this.activeReviews.concat(reply
+          .map((crData, index) => {
+            let _cr = new CodeReview();
+            return _cr.bootstrapFromStorage(crData, index);
+          })
+          .filter((codeReview) => {
+            return codeReview
+          }));
         console.log('\n', this.activeReviews.length, '\n');
       }));
   }


### PR DESCRIPTION
# Why?
- Because some PRs were stored in Redis without message ids

# What changed?
- This gets rid of them on the fly during application bootstrapping.