### PR TITLE
Add an endpoint for a mobile list

### DIFF
--- a/lib/api.slack.js
+++ b/lib/api.slack.js
@@ -55,7 +55,7 @@ class SlackAPI {
     }
   }
 
-  makeCRQueueFilteredNoItems() {
+  makeCRQueueNoItems() {
     return {
       response_type: "ephemeral",
       text: "No active code reviews found for your provided filters.",

--- a/lib/api.slack.js
+++ b/lib/api.slack.js
@@ -55,6 +55,15 @@ class SlackAPI {
     }
   }
 
+  makeCRQueueFilteredNoItems() {
+    return {
+      response_type: "ephemeral",
+      text: "No active code reviews found for your provided filters.",
+      as_user: true,
+      unfurl_links: false
+    }
+  }
+
   createCRMessage(codeReview) {
     let options = this._requestOptions("chat.postMessage", this.makeCRMessageData(codeReview));
 

--- a/lib/crbot.js
+++ b/lib/crbot.js
@@ -78,29 +78,25 @@ class CrBot {
   }
 
   onIncomingPRQueue(req, res, next) {
-    let channel_id = req.body.channel_id;
-    console.log(CrBot, 'onIncomingPRQueue', this.activeReviews.length);
-    let response = this.slack.makeCRQueueMessageData(this.activeReviews.filter((cr) => {
-      return !!cr.poll;
-    }), channel_id);
-    res.status(200).send(response);
-  }
-
-  onIncomingPRQueueFiltered(req, res, next) {
     let filters = req.body.text.split(" ");
     let channel_id = req.body.channel_id;
-    let activeFilteredReviews = this.activeReviews.filter((cr) => {
-      var filtered = [];
-      for (var i = 0; i < filters.length; i++) {
-        filtered.push(cr._typeEmojis().indexOf(filters[i]) > -1)
-      }
-      return filtered.indexOf(true) > -1
-    })
-    console.log(CrBot, 'onIncomingPRQueueFiltered', activeFilteredReviews.length);
+    var activeFilteredReviews;
+    if (filters) {
+      activeFilteredReviews = this.activeReviews.filter((cr) => {
+        var filtered = [];
+        for (var i = 0; i < filters.length; i++) {
+          filtered.push(cr._typeEmojis().indexOf(filters[i]) > -1);
+        }        
+        return filtered.indexOf(true) > -1
+      })
+    } else {
+      activeFilteredReviews = this.activeReviews;
+    }
+    console.log(CrBot, 'onIncomingPRQueue', activeFilteredReviews.length);
     let response = this.slack.makeCRQueueMessageData(activeFilteredReviews.filter((cr) => {
-        return !!cr.poll;
+      return !!cr.poll;
     }), channel_id);
-    res.status(200).send(activeFilteredReviews.length > 0 ? response : this.slack.makeCRQueueFilteredNoItems());
+    res.status(200).send(activeFilteredReviews.length > 0 ? response : this.slack.makeCRQueueNoItems());
   }
 
   setup() {
@@ -108,7 +104,6 @@ class CrBot {
 
     app.post('/code_review', this.onIncomingCodeReview.bind(this));
     app.post('/pr_queue', this.onIncomingPRQueue.bind(this));
-    app.post('/pr_queue_filtered', this.onIncomingPRQueueFiltered.bind(this));
     this.github = require('./api.github');
     this.github.authenticate(this.config);
 

--- a/lib/crbot.js
+++ b/lib/crbot.js
@@ -56,7 +56,6 @@ class CrBot {
           this.onSlackMessageIsBad(res, req);
           var err = (new Error(`Slack Message Did Not Contain a URL that could be found: ${req.body.text}`));
           throw err;
-          return err;
         }
 
         newCR = new CodeReview(githubResponse, githubPRParams, req.body);
@@ -87,12 +86,26 @@ class CrBot {
     res.status(200).send(response);
   }
 
+  onIncomingPRQueueMobile(req, res, next) {
+    let channel_id = req.body.channel_id;
+    let activeMobileReviews = this.activeReviews.filter((cr) => {
+      return cr._typeEmojis().indexOf(":cr-ios:") > -1 ||
+      cr._typeEmojis().indexOf(":cr-swift:") > -1 || 
+      cr._typeEmojis().indexOf(":cr-android:") > -1;
+    })
+    console.log(CrBot, 'onIncomingPRQueue', activeMobileReviews.length);
+    let response = this.slack.makeCRQueueMessageData(activeMobileReviews.filter((cr) => {
+      return !!cr.poll;
+    }), channel_id);
+    res.status(200).send(response);
+  }
+
   setup() {
     app.use(bodyParser.urlencoded({extended: true}));
 
     app.post('/code_review', this.onIncomingCodeReview.bind(this));
     app.post('/pr_queue', this.onIncomingPRQueue.bind(this));
-
+    app.post('/pr_queue_mobile', this.onIncomingPRQueueMobile.bind(this));
     this.github = require('./api.github');
     this.github.authenticate(this.config);
 

--- a/lib/crbot.js
+++ b/lib/crbot.js
@@ -86,18 +86,21 @@ class CrBot {
     res.status(200).send(response);
   }
 
-  onIncomingPRQueueMobile(req, res, next) {
+  onIncomingPRQueueFiltered(req, res, next) {
+    let filters = req.body.text.split(" ");
     let channel_id = req.body.channel_id;
-    let activeMobileReviews = this.activeReviews.filter((cr) => {
-      return cr._typeEmojis().indexOf(":cr-ios:") > -1 ||
-      cr._typeEmojis().indexOf(":cr-swift:") > -1 || 
-      cr._typeEmojis().indexOf(":cr-android:") > -1;
+    let activeFilteredReviews = this.activeReviews.filter((cr) => {
+      var filtered = [];
+      for (var i = 0; i < filters.length; i++) {
+        filtered.push(cr._typeEmojis().indexOf(filters[i]) > -1)
+      }
+      return filtered.indexOf(true) > -1
     })
-    console.log(CrBot, 'onIncomingPRQueue', activeMobileReviews.length);
-    let response = this.slack.makeCRQueueMessageData(activeMobileReviews.filter((cr) => {
-      return !!cr.poll;
+    console.log(CrBot, 'onIncomingPRQueueFiltered', activeFilteredReviews.length);
+    let response = this.slack.makeCRQueueMessageData(activeFilteredReviews.filter((cr) => {
+        return !!cr.poll;
     }), channel_id);
-    res.status(200).send(response);
+    res.status(200).send(activeFilteredReviews.length > 0 ? response : this.slack.makeCRQueueFilteredNoItems());
   }
 
   setup() {
@@ -105,7 +108,7 @@ class CrBot {
 
     app.post('/code_review', this.onIncomingCodeReview.bind(this));
     app.post('/pr_queue', this.onIncomingPRQueue.bind(this));
-    app.post('/pr_queue_mobile', this.onIncomingPRQueueMobile.bind(this));
+    app.post('/pr_queue_filtered', this.onIncomingPRQueueFiltered.bind(this));
     this.github = require('./api.github');
     this.github.authenticate(this.config);
 


### PR DESCRIPTION
# Why
- Nice to see only open mobile PRs for use in the `#mobile` Slack channel (mostly for shaming purposes).
# What
- Add a `/pr_queue_mobile` endpoint that returns a filtered list of active reviews of mobile projects
